### PR TITLE
Passive reopening: resume automation after manual override

### DIFF
--- a/custom_components/smart_cover_automation/cover_automation.py
+++ b/custom_components/smart_cover_automation/cover_automation.py
@@ -211,7 +211,6 @@ class CoverAutomation:
         was_manual_override_blocking = self._cover_pos_history_mgr.was_manual_override_blocking(self.entity_id)
         manual_override_remaining = self._get_manual_override_remaining(current_pos)
         if manual_override_remaining is not None:
-            self._cover_pos_history_mgr.clear_closed_by_automation(self.entity_id)
             self._cover_pos_history_mgr.clear_delayed_reopen_action(self.entity_id)
             if self._should_ignore_manual_override(sensor_data):
                 self._cover_pos_history_mgr.clear_manual_override_blocked(self.entity_id)
@@ -640,6 +639,20 @@ class CoverAutomation:
             expires_at=expires_at,
         )
 
+    def _is_passive_reopening_eligible(self, current_pos: int) -> bool:
+        """Return whether passive reopening may resume automation ownership.
+
+        Passive reopening should only resume when the cover is still at the last
+        position automation considered owned. This lets a user briefly move the
+        cover and hand control back by returning it to that same position.
+        """
+
+        last_history_entry = self._cover_pos_history_mgr.get_latest_entry(self.entity_id)
+        if last_history_entry is None:
+            return True
+
+        return current_pos == last_history_entry.position
+
     #
     # _should_ignore_manual_override
     #
@@ -782,9 +795,12 @@ class CoverAutomation:
             else:
                 reopening_mode = self.resolved.automatic_reopening_mode
                 open_target = min(const.COVER_POS_FULLY_OPEN, self._get_cover_closure_limit(get_max=False))
-                reopening_allowed = reopening_mode == const.ReopeningMode.ACTIVE or (
-                    reopening_mode == const.ReopeningMode.PASSIVE and last_automation_closing_reason is not None
+                passive_reopening_eligible = (
+                    reopening_mode == const.ReopeningMode.PASSIVE
+                    and last_automation_closing_reason is not None
+                    and self._is_passive_reopening_eligible(current_pos)
                 )
+                reopening_allowed = reopening_mode == const.ReopeningMode.ACTIVE or (passive_reopening_eligible)
 
                 if reopening_allowed and self._should_delay_heat_protection_reopen(last_automation_closing_reason):
                     delay_minutes = self.resolved.tilt_open_to_cover_open_delay
@@ -821,7 +837,7 @@ class CoverAutomation:
                         last_automation_closing_reason,
                         manual_override_just_expired=manual_override_just_expired,
                     )
-                elif reopening_mode == const.ReopeningMode.PASSIVE and last_automation_closing_reason is not None:
+                elif passive_reopening_eligible:
                     self._cover_pos_history_mgr.clear_delayed_reopen_action(self.entity_id)
                     desired_pos = open_target
                     desired_pos_friendly_name = (

--- a/tests/coordinator/test_manual_override.py
+++ b/tests/coordinator/test_manual_override.py
@@ -129,8 +129,8 @@ class TestManualOverride(TestDataUpdateCoordinatorBase):
         assert cover_result.pos_target_desired is not None
         assert cover_result.pos_target_desired == 0  # Fully closed
 
-    async def test_manual_override_expiry_logs_manual_override_end_reason(self, mock_hass: MagicMock) -> None:
-        """Manual override expiry should emit the dedicated reopen reason in a full coordinator cycle."""
+    async def test_manual_override_expiry_logs_heat_protection_end_reason_after_hand_back(self, mock_hass: MagicMock) -> None:
+        """Manual override expiry should resume the original heat-protection reopen reason after hand-back."""
 
         mock_hass.config = MagicMock()
         mock_hass.config.language = "en"
@@ -156,6 +156,7 @@ class TestManualOverride(TestDataUpdateCoordinatorBase):
             f"{base_key}.{const.TRANSL_LOGBOOK_VERB_OPENING}.{const.TRANSL_ATTR_NAME}": "Opening",
             f"{base_key}.{const.TRANSL_LOGBOOK_VERB_CLOSING}.{const.TRANSL_ATTR_NAME}": "Closing",
             f"{base_key}.{const.TRANSL_LOGBOOK_REASON_HEAT_PROTECTION}.{const.TRANSL_ATTR_NAME}": "protect from heat",
+            f"{base_key}.{const.TRANSL_LOGBOOK_REASON_END_HEAT_PROTECTION}.{const.TRANSL_ATTR_NAME}": "end heat protection",
             f"{base_key}.{const.TRANSL_LOGBOOK_REASON_END_MANUAL_OVERRIDE}.{const.TRANSL_ATTR_NAME}": "manual override ended",
             f"{base_key}.{const.TRANSL_LOGBOOK_TEMPLATE_COVER_MOVEMENT}.{const.TRANSL_ATTR_NAME}": "{verb} {entity_id} to {reason}. New position: {position}%.",
         }
@@ -217,7 +218,7 @@ class TestManualOverride(TestDataUpdateCoordinatorBase):
             assert third_cover_result.pos_target_final == 100
             assert coordinator._ha_interface.set_cover_position.await_count == 2
             assert mock_log_entry.call_count == 2
-            assert "manual override ended" in mock_log_entry.call_args.kwargs["message"]
+            assert "end heat protection" in mock_log_entry.call_args.kwargs["message"]
 
     async def test_no_manual_override_same_position(self, mock_hass: MagicMock) -> None:
         """Test that no manual override is detected when position hasn't changed.

--- a/tests/cover_automation/test_cover_automation.py
+++ b/tests/cover_automation/test_cover_automation.py
@@ -1474,6 +1474,43 @@ class TestCalculateDesiredPosition:
         assert lockout_active is False
         mock_cover_pos_history_mgr.set_delayed_reopen_action.assert_not_called()
 
+    def test_calculate_desired_position_passive_does_not_arm_or_keep_delayed_reopen_away_from_owned_state(
+        self, cover_automation, mock_resolved_config, mock_cover_pos_history_mgr
+    ):
+        """Passive mode should cancel delayed reopen while the user leaves the cover away from the automation-owned position."""
+
+        mock_resolved_config.automatic_reopening_mode = ReopeningMode.PASSIVE
+        mock_resolved_config.tilt_mode_day = TiltMode.AUTO
+        mock_resolved_config.tilt_open_to_cover_open_delay = 2
+        mock_cover_pos_history_mgr.get_closed_by_automation_reason.return_value = const.TRANSL_LOGBOOK_REASON_HEAT_PROTECTION
+        mock_cover_pos_history_mgr.get_latest_entry.return_value = PositionEntry(
+            position=0,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=5),
+            cover_moved=True,
+        )
+        mock_cover_pos_history_mgr.get_delayed_reopen_action.return_value = MagicMock(
+            reopen_at=datetime.now(timezone.utc) + timedelta(seconds=30)
+        )
+
+        sensor_data = make_sensor_data(
+            sun_azimuth=180.0,
+            sun_elevation=45.0,
+            temp_max=20.0,
+            temp_hot=False,
+            weather_condition="cloudy",
+            weather_sunny=False,
+            evening_closure=False,
+            post_evening_closure=False,
+        )
+
+        position, reason, lockout_active = cover_automation._calculate_desired_position(sensor_data, sun_hitting=False, current_pos=50)
+
+        assert position == 50
+        assert reason is None
+        assert lockout_active is False
+        mock_cover_pos_history_mgr.set_delayed_reopen_action.assert_not_called()
+        mock_cover_pos_history_mgr.clear_delayed_reopen_action.assert_called_once_with("cover.test")
+
     def test_calculate_desired_position_after_manual_override_expired(self, cover_automation):
         """Active mode should use a dedicated reopening reason when manual override just expired."""
 
@@ -2657,6 +2694,38 @@ class TestMaoveCoverIfNeeded:
         mock_cover_pos_history_mgr.clear_manual_override_blocked.assert_called_once_with("cover.test")
         call_kwargs = mock_ha_interface.add_logbook_entry.call_args[1]
         assert call_kwargs["reason_key"] == const.TRANSL_LOGBOOK_REASON_END_MANUAL_OVERRIDE
+
+    async def test_process_passive_reopens_after_manual_override_expiry_when_cover_returned_to_owned_state(
+        self, cover_automation, mock_cover_pos_history_mgr, mock_state, sensor_data, mock_resolved_config, mock_ha_interface
+    ):
+        """Passive mode should reopen again after manual override expiry once the user returned the cover to the automation-owned position."""
+
+        mock_resolved_config.automatic_reopening_mode = ReopeningMode.PASSIVE
+        entry = PositionEntry(position=0, timestamp=datetime.now(timezone.utc) - timedelta(seconds=3700), cover_moved=True)
+        mock_cover_pos_history_mgr.get_latest_entry.return_value = entry
+        mock_cover_pos_history_mgr.was_manual_override_blocking.return_value = True
+        mock_cover_pos_history_mgr.get_closed_by_automation_reason.return_value = const.TRANSL_LOGBOOK_REASON_HEAT_PROTECTION
+        mock_state.attributes[ATTR_CURRENT_POSITION] = 0
+        mock_ha_interface.set_cover_position.return_value = 100
+
+        sensor_data = make_sensor_data(
+            sun_azimuth=180.0,
+            sun_elevation=45.0,
+            temp_max=20.0,
+            temp_hot=False,
+            weather_condition="cloudy",
+            weather_sunny=False,
+            evening_closure=False,
+            post_evening_closure=False,
+        )
+
+        result = await cover_automation.process(mock_state, sensor_data)
+
+        assert result.pos_target_desired == 100
+        assert result.pos_target_final == 100
+        mock_cover_pos_history_mgr.clear_manual_override_blocked.assert_called_once_with("cover.test")
+        call_kwargs = mock_ha_interface.add_logbook_entry.call_args[1]
+        assert call_kwargs["reason_key"] == const.TRANSL_LOGBOOK_REASON_END_HEAT_PROTECTION
 
     async def test_move_cover_if_needed_closing_after_sunset(self, cover_automation, mock_ha_interface, mock_cover_pos_history_mgr):
         """Test moving cover after sunset."""

--- a/tests/cover_automation/test_cover_automation.py
+++ b/tests/cover_automation/test_cover_automation.py
@@ -1024,14 +1024,14 @@ class TestMovementReasonHelpers:
 
         assert result is False
 
-    async def test_process_clears_automation_closed_marker_on_manual_override(
+    async def test_process_keeps_automation_closed_marker_available_during_manual_override(
         self,
         cover_automation,
         mock_cover_pos_history_mgr,
         mock_state,
         sensor_data,
     ):
-        """Manual override should clear passive reopening eligibility."""
+        """Manual override should keep passive reopening resumable after returning to the prior state."""
 
         entry = PositionEntry(position=0, timestamp=datetime.now(timezone.utc) - timedelta(seconds=30), cover_moved=True)
         mock_cover_pos_history_mgr.get_latest_entry.return_value = entry
@@ -1039,7 +1039,7 @@ class TestMovementReasonHelpers:
 
         await cover_automation.process(mock_state, sensor_data)
 
-        mock_cover_pos_history_mgr.clear_closed_by_automation.assert_called_once_with("cover.test")
+        mock_cover_pos_history_mgr.clear_closed_by_automation.assert_not_called()
 
     def test_get_evening_closure_movement_reason_for_keep_closed(self, cover_automation, sensor_data, mock_resolved_config):
         """Test overnight keep-closed maps to its dedicated evening movement reason."""
@@ -1259,6 +1259,11 @@ class TestCalculateDesiredPosition:
 
         mock_resolved_config.automatic_reopening_mode = ReopeningMode.PASSIVE
         mock_cover_pos_history_mgr.get_closed_by_automation_reason.return_value = const.TRANSL_LOGBOOK_REASON_HEAT_PROTECTION
+        mock_cover_pos_history_mgr.get_latest_entry.return_value = PositionEntry(
+            position=50,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=5),
+            cover_moved=True,
+        )
 
         sensor_data = make_sensor_data(
             sun_azimuth=180.0,
@@ -1274,6 +1279,36 @@ class TestCalculateDesiredPosition:
         position, reason, lockout_active = cover_automation._calculate_desired_position(sensor_data, sun_hitting=False, current_pos=50)
         assert position == 100
         assert reason == CoverMovementReason.OPENING_AFTER_HEAT_PROTECTION
+        assert lockout_active is False
+
+    def test_calculate_desired_position_passive_keeps_position_until_user_returns_to_automation_owned_state(
+        self, cover_automation, mock_resolved_config, mock_cover_pos_history_mgr
+    ):
+        """Passive mode should wait while the user leaves the cover away from the last automation-owned position."""
+
+        mock_resolved_config.automatic_reopening_mode = ReopeningMode.PASSIVE
+        mock_cover_pos_history_mgr.get_closed_by_automation_reason.return_value = const.TRANSL_LOGBOOK_REASON_HEAT_PROTECTION
+        mock_cover_pos_history_mgr.get_latest_entry.return_value = PositionEntry(
+            position=0,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=5),
+            cover_moved=True,
+        )
+
+        sensor_data = make_sensor_data(
+            sun_azimuth=180.0,
+            sun_elevation=45.0,
+            temp_max=20.0,
+            temp_hot=False,
+            weather_condition="cloudy",
+            weather_sunny=False,
+            evening_closure=False,
+            post_evening_closure=False,
+        )
+
+        position, reason, lockout_active = cover_automation._calculate_desired_position(sensor_data, sun_hitting=False, current_pos=50)
+
+        assert position == 50
+        assert reason is None
         assert lockout_active is False
 
     def test_calculate_desired_position_passive_keeps_position_without_automation_closure(


### PR DESCRIPTION
When the user opens a cover temporarily that was closed by automation, and then re-closes it (to the same position it was in before), the automation now resumes control.