### PR TITLE
After long cover closing, automation gives up ownership & doesn't reopen in passive mode

### DIFF
--- a/custom_components/smart_cover_automation/cover_automation.py
+++ b/custom_components/smart_cover_automation/cover_automation.py
@@ -666,6 +666,10 @@ class CoverAutomation:
         cover and hand control back by returning it to that same position.
         """
 
+        automation_owned_position = self._cover_pos_history_mgr.get_automation_owned_position(self.entity_id)
+        if isinstance(automation_owned_position, int):
+            return current_pos == automation_owned_position
+
         last_history_entry = self._cover_pos_history_mgr.get_latest_entry(self.entity_id)
         if last_history_entry is None:
             return True
@@ -1117,6 +1121,7 @@ class CoverAutomation:
                     self.entity_id,
                     self._get_closing_logbook_reason_key(movement_reason),
                 )
+                self._cover_pos_history_mgr.set_automation_owned_position(self.entity_id, actual_pos)
             else:
                 self._cover_pos_history_mgr.clear_closed_by_automation(self.entity_id)
 

--- a/custom_components/smart_cover_automation/cover_position_history.py
+++ b/custom_components/smart_cover_automation/cover_position_history.py
@@ -93,6 +93,7 @@ class CoverPositionHistoryManager:
 
     __slots__ = (
         "_automation_closed_markers",
+        "_automation_owned_positions",
         "_cover_position_history",
         "_delayed_reopen_actions",
         "_manual_override_blocked",
@@ -103,6 +104,7 @@ class CoverPositionHistoryManager:
     def __init__(self, on_closed_by_automation_changed: Callable[[dict[str, str]], None] | None = None) -> None:
         """Initialize the position history manager."""
         self._automation_closed_markers: dict[str, str] = {}
+        self._automation_owned_positions: dict[str, int] = {}
         self._cover_position_history: dict[str, CoverPositionHistory] = {}
         self._delayed_reopen_actions: dict[str, DelayedReopenAction] = {}
         self._manual_override_blocked: set[str] = set()
@@ -238,8 +240,20 @@ class CoverPositionHistoryManager:
         self._automation_closed_markers[entity_id] = reason_key
         self._notify_closed_by_automation_changed()
 
+    def set_automation_owned_position(self, entity_id: str, position: int) -> None:
+        """Store the closed position automation currently owns for passive reopening."""
+
+        self._automation_owned_positions[entity_id] = position
+
+    def get_automation_owned_position(self, entity_id: str) -> int | None:
+        """Return the closed position automation currently owns for a cover."""
+
+        return self._automation_owned_positions.get(entity_id)
+
     def clear_closed_by_automation(self, entity_id: str) -> None:
         """Clear the automation-closed marker for a cover."""
+
+        self._automation_owned_positions.pop(entity_id, None)
 
         if entity_id not in self._automation_closed_markers:
             return

--- a/custom_components/smart_cover_automation/manifest.json
+++ b/custom_components/smart_cover_automation/manifest.json
@@ -13,5 +13,5 @@
     "documentation": "https://ha-smart-cover-automation.helgeklein.com/",
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/helgeklein/ha-smart-cover-automation/issues",
-    "version": "5.0.0"
+    "version": "5.1.0"
 }

--- a/tests/coordinator/test_manual_override.py
+++ b/tests/coordinator/test_manual_override.py
@@ -7,12 +7,14 @@ and edge cases.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.components.cover import ATTR_CURRENT_POSITION, ATTR_CURRENT_TILT_POSITION, CoverEntityFeature
-from homeassistant.const import ATTR_SUPPORTED_FEATURES
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_CLOSED, STATE_CLOSING
 from homeassistant.helpers import entity_registry as ha_entity_registry
 
 from custom_components.smart_cover_automation import const
@@ -219,6 +221,78 @@ class TestManualOverride(TestDataUpdateCoordinatorBase):
             assert coordinator._ha_interface.set_cover_position.await_count == 2
             assert mock_log_entry.call_count == 2
             assert "end heat protection" in mock_log_entry.call_args.kwargs["message"]
+
+    async def test_passive_reopening_resumes_after_multi_cycle_heat_protection_close(
+        self,
+        mock_hass: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Passive reopening should survive a heat-protection close that spans multiple coordinator cycles."""
+
+        caplog.set_level(logging.INFO, logger="custom_components.smart_cover_automation")
+
+        config_data = create_sun_config()
+        config_data[ConfKeys.MANUAL_OVERRIDE_DURATION.value] = 1800
+        config_data[ConfKeys.AUTOMATIC_REOPENING_MODE.value] = const.ReopeningMode.PASSIVE.value
+        config_entry = MockConfigEntry(config_data)
+
+        coordinator = DataUpdateCoordinator(mock_hass, cast(IntegrationConfigEntry, config_entry))
+        coordinator._ha_interface.set_cover_position = AsyncMock(side_effect=[0, 100])
+        coordinator._ha_interface.add_logbook_entry = AsyncMock()
+
+        set_weather_forecast_temp(float(TEST_HOT_TEMP))
+
+        state_mapping = create_combined_state_mock(
+            sun_azimuth=180.0,
+            cover_states={
+                MOCK_COVER_ENTITY_ID: {
+                    ATTR_CURRENT_POSITION: 100,
+                    ATTR_SUPPORTED_FEATURES: int(CoverEntityFeature.SET_POSITION),
+                }
+            },
+        )
+        mock_hass.states.get.side_effect = lambda entity_id: state_mapping.get(entity_id)
+
+        first_result = await coordinator._async_update_data()
+
+        first_cover_result = first_result.covers[MOCK_COVER_ENTITY_ID]
+        assert first_cover_result.pos_target_final == 0
+        assert coordinator._ha_interface.set_cover_position.await_count == 1
+
+        state_mapping[MOCK_COVER_ENTITY_ID].state = STATE_CLOSING
+        state_mapping[MOCK_COVER_ENTITY_ID].attributes = {
+            ATTR_CURRENT_POSITION: 50,
+            ATTR_SUPPORTED_FEATURES: int(CoverEntityFeature.SET_POSITION),
+        }
+
+        second_result = await coordinator._async_update_data()
+
+        second_cover_result = second_result.covers[MOCK_COVER_ENTITY_ID]
+        assert second_cover_result.state == STATE_CLOSING
+        assert second_cover_result.pos_target_desired is None
+        assert coordinator._ha_interface.set_cover_position.await_count == 1
+
+        state_mapping[MOCK_COVER_ENTITY_ID].state = STATE_CLOSED
+        state_mapping[MOCK_COVER_ENTITY_ID].attributes = {
+            ATTR_CURRENT_POSITION: 0,
+            ATTR_SUPPORTED_FEATURES: int(CoverEntityFeature.SET_POSITION),
+        }
+
+        third_result = await coordinator._async_update_data()
+
+        third_cover_result = third_result.covers[MOCK_COVER_ENTITY_ID]
+        assert third_cover_result.pos_current == 0
+        assert third_cover_result.pos_target_desired == 0
+        assert coordinator._ha_interface.set_cover_position.await_count == 1
+
+        set_weather_forecast_temp(20.0)
+        state_mapping[MOCK_SUN_ENTITY_ID].attributes = {"elevation": 45.0, "azimuth": 90.0}
+
+        fourth_result = await coordinator._async_update_data()
+
+        fourth_cover_result = fourth_result.covers[MOCK_COVER_ENTITY_ID]
+        assert fourth_cover_result.pos_target_final == 100
+        assert coordinator._ha_interface.set_cover_position.await_count == 2
 
     async def test_no_manual_override_same_position(self, mock_hass: MagicMock) -> None:
         """Test that no manual override is detected when position hasn't changed.

--- a/tests/cover_automation/test_cover_automation.py
+++ b/tests/cover_automation/test_cover_automation.py
@@ -90,6 +90,8 @@ def mock_cover_pos_history_mgr():
     mgr.set_recent_automation_action = MagicMock()
     mgr.clear_recent_automation_action = MagicMock()
     mgr.mark_closed_by_automation = MagicMock()
+    mgr.set_automation_owned_position = MagicMock()
+    mgr.get_automation_owned_position = MagicMock(return_value=None)
     mgr.clear_closed_by_automation = MagicMock()
     mgr.set_delayed_reopen_action = MagicMock()
     mgr.get_delayed_reopen_action = MagicMock(return_value=None)
@@ -1444,6 +1446,37 @@ class TestCalculateDesiredPosition:
         )
 
         position, reason, lockout_active = cover_automation._calculate_desired_position(sensor_data, sun_hitting=False, current_pos=50)
+        assert position == 100
+        assert reason == CoverMovementReason.OPENING_AFTER_HEAT_PROTECTION
+        assert lockout_active is False
+
+    def test_calculate_desired_position_passive_reopens_after_automation_closure_with_stale_latest_history(
+        self, cover_automation, mock_resolved_config, mock_cover_pos_history_mgr
+    ):
+        """Passive reopening should rely on automation ownership, not the mutable latest history entry."""
+
+        mock_resolved_config.automatic_reopening_mode = ReopeningMode.PASSIVE
+        mock_cover_pos_history_mgr.get_closed_by_automation_reason.return_value = const.TRANSL_LOGBOOK_REASON_HEAT_PROTECTION
+        mock_cover_pos_history_mgr.get_automation_owned_position.return_value = 0
+        mock_cover_pos_history_mgr.get_latest_entry.return_value = PositionEntry(
+            position=50,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=5),
+            cover_moved=True,
+        )
+
+        sensor_data = make_sensor_data(
+            sun_azimuth=180.0,
+            sun_elevation=45.0,
+            temp_max=20.0,
+            temp_hot=False,
+            weather_condition="cloudy",
+            weather_sunny=False,
+            evening_closure=False,
+            post_evening_closure=False,
+        )
+
+        position, reason, lockout_active = cover_automation._calculate_desired_position(sensor_data, sun_hitting=False, current_pos=0)
+
         assert position == 100
         assert reason == CoverMovementReason.OPENING_AFTER_HEAT_PROTECTION
         assert lockout_active is False


### PR DESCRIPTION
Reproduction:

- Cycle 1: cover at 100%, heat protection active, automation commands close to 0%.
- Cycle 2: cover state is closing, coordinator skips it.
- Cycle 3: cover state is closed, current position 0%, heat protection still active.
- Cycle 4: heat protection no longer applies, passive reopening mode is enabled.

**Expected:** cover reopens, because it was closed by automation and is still at the automation-owned closed position.

**Behavior before the fix:** cover stayed closed. The log showed "Current position: 0%, desired position: 0%, keeping current position because passive reopening only applies after automation closed this cover".